### PR TITLE
Add thread synchronization.

### DIFF
--- a/lib/canister/version.rb
+++ b/lib/canister/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Canister
-  VERSION = "0.9.1"
+  VERSION = "0.9.2"
 end

--- a/spec/canister_spec.rb
+++ b/spec/canister_spec.rb
@@ -114,4 +114,24 @@ RSpec.describe Canister do
     canister.register(:a) { "a" }
     expect(canister.resolve(:c)).to eql("abc")
   end
+
+  it "is apparently thread safe" do
+    threads = []
+    canister.register(:a) { "a" }
+    1000.times do
+      canister.register(:b) do |c|
+        threads << Thread.new do
+          loop do
+            sleep 0.1
+            c[:a]
+          end
+        end
+        "b"
+      end
+      canister.resolve(:b)
+    end
+    sleep 3
+    expect(canister.resolve(:b)).to eql("b")
+    threads.each(&:kill)
+  end
 end


### PR DESCRIPTION
- Add `@mutex` ivar.
- Wrap array and hash mutating methods with `@mutex.synchronize`.
- Add janky thread safety test which (via serendipity) fails with the pre-mutexed version of the code.

Note: tested against jruby 9.4.2.0 (3.1.0) and MRI 3.1.4