### PR TITLE
Provide a non-threadsafe mechanism to override registered values

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,27 @@ container.wait    #=> 27
 # Caches are invalidated automatically
 container.register(:foo) { "oof" }
 container.bar     #=> "oofbar"
+
+
+# Temporarily override
+
+container = Canister.new
+container.register(:a) { "a" }.register(:b) {|c| c.a + "b" }.register(:c) {|c| c.b + "c"}
+container.c #=> "abc"
+container.push_context!
+container.register(:a) { "Z" }
+container.c #=> "abZ"
+container.pop_context!
+container.c #=> "abc"
+
+# Or override within a block
+
+container.override do
+  container.register(:b) {|c| c.a + "Z" }
+  container.c #=> "aZc"
+end
+
+
 ```
 
 ## Contributing

--- a/lib/canister.rb
+++ b/lib/canister.rb
@@ -10,7 +10,7 @@ class Canister < SimpleDelegator
 
   def initialize(&blk)
     @context_stack = []
-    _push_context(new_context: Context.new)
+    push_context!(new_context: Context.new)
     yield self if block_given?
   end
 
@@ -23,16 +23,16 @@ class Canister < SimpleDelegator
   # Push a new (presumably temporary) context onto the stack from which to resolve values
   # @param new_context [Context] The new context; by default, just a copy of the current registry
   # @return [Canister] self
-  def _push_context(new_context: @context.dup)
+  def push_context!(new_context: @context.dup)
     @context_stack.push(new_context)
     @context = @context_stack.last
     __setobj__(@context)
     self
   end
 
-  # Pop a context off the stack, returning the resolution context to what it was before the last #_push_context
+  # Pop a context off the stack, returning the resolution context to what it was before the last #push_context
   # @return [Canister] self
-  def _pop_context
+  def pop_context!
     raise "Can't pop context_stack if there's only one thing in it" unless @context_stack.size > 1
     @context_stack.pop
     @context = @context_stack.last
@@ -43,9 +43,9 @@ class Canister < SimpleDelegator
   # NOT THREAD SAFE. NOT EVEN A LITTLE.
   # @return [Canister] self
   def override(&blk)
-    _push_context
+    push_context!
     blk.call
-    _pop_context
+    pop_context!
     self
   end
 

--- a/lib/canister.rb
+++ b/lib/canister.rb
@@ -1,112 +1,164 @@
 # frozen_string_literal: true
 
 require "canister/version"
-
+require "delegate"
 # A container that registers keys to values that are
 # resolved at runtime. This allows for out-of-order declaration,
 # automatic dependency resolution, and--upon
 # redeclaration--automatic dependency cache invalidation.
-class Canister
-  def initialize
-    @stack = []
-    @registry = {}
-    @resolved = {}
-    @dependents = Hash.new do |hash, key|
-      hash[key] = []
-    end
-    @mutex = Mutex.new
+class Canister < SimpleDelegator
+
+  def initialize(&blk)
+    @context_stack = []
+    _push_context(new_context: Context.new)
     yield self if block_given?
   end
 
-  # We override method_missing to enable dot notation
-  # for accessing registered values.
-  def method_missing(method, *args, &block)
-    if handles?(method)
-      resolve(method)
-    else
-      super(method, *args, block)
-    end
-  end
-
-  # We override respond_to? to enable dot notation
-  # for accessing registered values.
-  def respond_to_missing?(method, include_all = false)
-    handles?(method) || super(method, include_all)
-  end
-
-  def synchronize(&block)
-    if @mutex.owned?
-      yield
-    else
-      @mutex.synchronize(&block)
-    end
-  end
-
-  # Register a value to a key by passing a block. Note that
-  # the value will be that returned by the block. If the key
-  # has been registered before, the old registration is
-  # overwritten. Dependents of the original registration
-  # are automatically invalidated.
-  # @param key [Symbol]
-  # @yield self [Container] Yields this container.
-  # @return the value defined in the block
-  def register(key, &block)
-    key = key.to_sym
-    synchronize do
-      invalidate(key) if registered?(key)
-      registry[key] = block
-    end
+  # @overload Context#register() so it can return 'self' and not the context
+  def register(*args, **kwargs, &blk)
+    @context.register(*args, **kwargs, &blk)
     self
   end
 
-  # Recursively resolves the object that was registered to
-  # the key. This value is memoized.
-  # @param key [Symbol]
-  def resolve(key)
-    key = key.to_sym
-    value = nil
-    synchronize do
-      add_dependent(key)
-      stack << key
-      value = resolved[key] ||= registry[key].call(self)
-      stack.pop
+  # Push a new (presumably temporary) context onto the stack from which to resolve values
+  # @param new_context [Context] The new context; by default, just a copy of the current registry
+  # @return [Canister] self
+  def _push_context(new_context: @context.dup)
+    @context_stack.push(new_context)
+    @context = @context_stack.last
+    __setobj__(@context)
+    self
+  end
+
+  # Pop a context off the stack, returning the resolution context to what it was before the last #_push_context
+  # @return [Canister] self
+  def _pop_context
+    raise "Can't pop context_stack if there's only one thing in it" unless @context_stack.size > 1
+    @context_stack.pop
+    @context = @context_stack.last
+    __setobj__(@context)
+  end
+
+  # Evaluate the given block in a fresh context, allowing temporary overrides to registered procs.
+  # NOT THREAD SAFE. NOT EVEN A LITTLE.
+  # @return [Canister] self
+  def override(&blk)
+    _push_context
+    blk.call
+    _pop_context
+    self
+  end
+
+  class Context
+
+    # Set up a new context within which to register/resolve
+    def initialize(stack: [], registry: {}, resolved: {}, dependents: Hash.new { |h, k| h[k] = [] })
+      @stack = stack
+      @registry = registry
+      @resolved = resolved
+      @dependents = dependents
+      @mutex = Mutex.new
     end
-    value
-  end
-  alias_method :[], :resolve
 
-  def keys
-    registry.keys
-  end
-
-  private
-
-  attr_reader :dependents, :registry, :resolved, :stack
-
-  def handles?(method)
-    registered?(method)
-  end
-
-  def add_dependent(key)
-    unless stack.empty?
-      dependents[key] << stack.last
+    # Create a new context based on the current one by copying the registry and leaving everything else empty
+    # @return [Context] A new Context with a duplicate of the old registry
+    def dup
+      self.class.new(registry: @registry)
     end
-  end
 
-  def registered?(key)
-    registry.key?(key)
-  end
+    # We override method_missing to enable dot notation
+    # for accessing registered values.
+    def method_missing(method, *args, &block)
+      if handles?(method)
+        resolve(method)
+      else
+        super(method, *args, block)
+      end
+    end
 
-  def unresolve(key)
-    resolved.delete(key)
-  end
+    # We override respond_to? to enable dot notation
+    # for accessing registered values.
+    def respond_to_missing?(method, include_all = false)
+      handles?(method) || super(method, include_all)
+    end
 
-  def invalidate(key, first = true)
-    unresolve(key)
-    dependents[key]
-      .each { |child| invalidate(child, false) }
-    if first
-      dependents.delete(key)
+    # Run the given block in a local mutex
+    def synchronize(&block)
+      if @mutex.owned?
+        yield
+      else
+        @mutex.synchronize(&block)
+      end
+    end
+
+    # Register a value to a key by passing a block. Note that
+    # the value will be that returned by the block. If the key
+    # has been registered before, the old registration is
+    # overwritten. Dependents of the original registration
+    # are automatically invalidated.
+    # @param key [Symbol] The "name" of the registered key
+    # @yieldparam self [Context] Yields this container.
+    # @yieldreturn the value defined in the block
+    # @return [Context] self
+    def register(key, &block)
+      key = key.to_sym
+      synchronize do
+        invalidate(key) if registered?(key)
+        registry[key] = block
+      end
+      self
+    end
+
+    # Recursively resolves the object that was registered to
+    # the key. This value is memoized.
+    # @param key [Symbol]
+    def resolve(key)
+      key = key.to_sym
+      value = nil
+      synchronize do
+        add_dependent(key)
+        stack << key
+        value = resolved[key] ||= registry[key].call(self)
+        stack.pop
+      end
+      value
+    end
+
+    alias_method :[], :resolve
+
+    def keys
+      registry.keys
+    end
+
+    private
+
+    attr_reader :dependents, :registry, :resolved, :stack
+
+    def handles?(method)
+      registered?(method)
+    end
+
+    def add_dependent(key)
+      unless stack.empty?
+        dependents[key] << stack.last
+      end
+    end
+
+    def registered?(key)
+      registry.key?(key)
+    end
+
+    def unresolve(key)
+      resolved.delete(key)
+    end
+
+    def invalidate(key, first = true)
+      unresolve(key)
+      dependents[key]
+        .each { |child| invalidate(child, false) }
+      if first
+        dependents.delete(key)
+      end
     end
   end
 end

--- a/lib/canister/version.rb
+++ b/lib/canister/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-
-class Canister
+require "delegate"
+class Canister < SimpleDelegator
   VERSION = "0.9.2"
 end

--- a/spec/canister_spec.rb
+++ b/spec/canister_spec.rb
@@ -157,6 +157,19 @@ RSpec.describe Canister do
         end
         expect(canister.resolve(:c)).to eql("abc")
       end
+
+      it "overrides with a change in the stack" do
+        expect(canister.resolve(:c)).to eql("abc")
+        canister.push_context!
+        canister.register(:b) { |c| c.a + "B" }
+        canister.register(:c) { |c| c.d + "c" }
+        canister.register (:d) { |c| c.b + "D" }
+        expect(canister.c).to eql("aBDc")
+        canister.pop_context!
+        expect(canister.resolve(:c)).to eql("abc")
+
+      end
+
     end
 
     describe "override in rspec 'around'" do
@@ -169,6 +182,13 @@ RSpec.describe Canister do
       it "overrides with 'around'" do
         canister.register(:b) { |c| c.a + "OVERRIDE" }
         expect(canister.c).to eql("aOVERRIDEc")
+      end
+
+      it "overrides with a change in the stack" do
+        canister.register(:b) { |c| c.a + "B" }
+        canister.register(:c) { |c| c.d + "c" }
+        canister.register (:d) { |c| c.b + "D" }
+        expect(canister.c).to eql("aBDc")
       end
     end
 

--- a/spec/canister_spec.rb
+++ b/spec/canister_spec.rb
@@ -4,134 +4,173 @@ require_relative "spec_helper"
 require "canister"
 
 RSpec.describe Canister do
-  let(:canister) { described_class.new }
 
-  it "has a version number" do
-    expect(Canister::VERSION).not_to be nil
-  end
+  describe "basics" do
+    let(:canister) { described_class.new }
 
-  it "#new takes a block" do
-    container = described_class.new do |c|
-      c.register(:foo) { :bar }
+    it "has a version number" do
+      expect(Canister::VERSION).not_to be nil
     end
-    expect(container.resolve(:foo)).to eql(:bar)
-  end
 
-  it "resolves a simple variable" do
-    canister.register(:foo) { :bar }
-    expect(canister.resolve(:foo)).to eql(:bar)
-  end
-
-  it "#[] is equivalent to #resolve" do
-    canister.register(:foo) { :bar }
-    expect(canister[:foo]).to eql(canister.resolve(:foo))
-  end
-
-  it ".foo is equivalent to #resolve(:foo)" do
-    canister.register(:foo) { :bar }
-    expect(canister.foo).to eql(canister.resolve(:foo))
-  end
-
-  it "can resolve a symbol with a string" do
-    canister.register(:foo) { :bar }
-    expect(canister.resolve("foo")).to eql(:bar)
-  end
-
-  it "can resolve a string with a symbol" do
-    canister.register("foo") { :bar }
-    expect(canister.resolve(:foo)).to eql(:bar)
-  end
-
-  it "#register returns self" do
-    expect(canister.register(:foo) {}).to eql(canister)
-  end
-
-  it "memoizes the value" do
-    counter = 0
-    canister.register(:foo) { counter += 1 }
-    canister.resolve(:foo)
-    expect(canister.resolve(:foo)).to eql(1)
-  end
-
-  it "correctly sends method_missing for a missing key" do
-    expect { canister.to_s }.not_to raise_error
-    expect { canister.foo }.to raise_error(NoMethodError)
-  end
-
-  it "correctly answers #respond_to?" do
-    canister.register(:bar) { "bar" }
-    expect(canister.respond_to?(:to_s)).to be true
-    expect(canister.respond_to?(:foo)).to be false
-    expect(canister.respond_to?(:bar)).to be true
-  end
-
-  it "#keys returns the keys" do
-    canister.register(:foo) { :bar }
-    canister.register(:alice) { :bob }
-    expect(canister.keys).to contain_exactly(:foo, :alice)
-  end
-
-  it "allows nesting" do
-    canister.register(:a) { "a" }
-    canister.register(:b) { |c| c.a + "b" }
-    canister.register(:c) { |c| c.b + "c" }
-    expect(canister.resolve(:c)).to eql("abc")
-  end
-
-  it "allows a complex tree" do
-    canister.register(:a) { "a" }
-    canister.register(:b1) { |c| c.a + "b1" }
-    canister.register(:b2) { |c| c.a + "b2" }
-    canister.register(:c) { |c| c.b1 + c.b2 + "c" }
-    expect(canister.resolve(:c)).to eql("ab1ab2c")
-  end
-
-  it "resets the dependency sequence on reregister" do
-    canister.register(:a) { "a" }
-    canister.register(:b) { |c| c.a + "b" }
-    canister.register(:c) { |c| c.b + "c" }
-    canister.register(:d) { |c| c.c + "d" }
-    canister.register(:e) { |c| c.d + "e" }
-    canister.register(:f) { |c| c.e + "f" }
-    canister.resolve(:f)
-    canister.register(:a) { "x" }
-    expect(canister.resolve(:f)).to eql("xbcdef")
-  end
-
-  it "resets the dependency tree on reregister" do
-    canister.register(:a) { "a" }
-    canister.register(:b1) { |c| c.a + "b1" }
-    canister.register(:b2) { |c| c.a + "b2" }
-    canister.register(:c) { |c| c.b1 + c.b2 + "c" }
-    canister.resolve(:c)
-    canister.register(:a) { "x" }
-    expect(canister.resolve(:c)).to eql("xb1xb2c")
-  end
-
-  it "ignores order" do
-    canister.register(:c) { |c| c.b + "c" }
-    canister.register(:b) { |c| c.a + "b" }
-    canister.register(:a) { "a" }
-    expect(canister.resolve(:c)).to eql("abc")
-  end
-
-  it "is apparently thread safe" do
-    threads = []
-    canister.register(:a) { "a" }
-    1000.times do
-      canister.register(:b) do |c|
-        threads << Thread.new do
-          loop do
-            sleep 0.1
-            c[:a]
-          end
-        end
-        "b"
+    it "#new takes a block" do
+      container = described_class.new do |c|
+        c.register(:foo) { :bar }
       end
-      canister.resolve(:b)
+      expect(container.resolve(:foo)).to eql(:bar)
     end
-    sleep 3
-    expect(canister.resolve(:b)).to eql("b")
-    threads.each(&:kill)
+
+    it "resolves a simple variable" do
+      canister.register(:foo) { :bar }
+      expect(canister.resolve(:foo)).to eql(:bar)
+    end
+
+    it "#[] is equivalent to #resolve" do
+      canister.register(:foo) { :bar }
+      expect(canister[:foo]).to eql(canister.resolve(:foo))
+    end
+
+    it ".foo is equivalent to #resolve(:foo)" do
+      canister.register(:foo) { :bar }
+      expect(canister.foo).to eql(canister.resolve(:foo))
+    end
+
+    it "can resolve a symbol with a string" do
+      canister.register(:foo) { :bar }
+      expect(canister.resolve("foo")).to eql(:bar)
+    end
+
+    it "can resolve a string with a symbol" do
+      canister.register("foo") { :bar }
+      expect(canister.resolve(:foo)).to eql(:bar)
+    end
+
+    it "#register returns self" do
+      expect(canister.register(:foo) {}).to eql(canister)
+    end
+
+    it "memoizes the value" do
+      counter = 0
+      canister.register(:foo) { counter += 1 }
+      canister.resolve(:foo)
+      expect(canister.resolve(:foo)).to eql(1)
+    end
+
+    it "correctly sends method_missing for a missing key" do
+      expect { canister.to_s }.not_to raise_error
+      expect { canister.foo }.to raise_error(NoMethodError)
+    end
+
+    it "correctly answers #respond_to?" do
+      canister.register(:bar) { "bar" }
+      expect(canister.respond_to?(:to_s)).to be true
+      expect(canister.respond_to?(:foo)).to be false
+      expect(canister.respond_to?(:bar)).to be true
+    end
+
+    it "#keys returns the keys" do
+      canister.register(:foo) { :bar }
+      canister.register(:alice) { :bob }
+      expect(canister.keys).to contain_exactly(:foo, :alice)
+    end
+
+    it "allows nesting" do
+      canister.register(:a) { "a" }
+      canister.register(:b) { |c| c.a + "b" }
+      canister.register(:c) { |c| c.b + "c" }
+      expect(canister.resolve(:c)).to eql("abc")
+    end
+
+    it "allows a complex tree" do
+      canister.register(:a) { "a" }
+      canister.register(:b1) { |c| c.a + "b1" }
+      canister.register(:b2) { |c| c.a + "b2" }
+      canister.register(:c) { |c| c.b1 + c.b2 + "c" }
+      expect(canister.resolve(:c)).to eql("ab1ab2c")
+    end
+
+    it "resets the dependency sequence on reregister" do
+      canister.register(:a) { "a" }
+      canister.register(:b) { |c| c.a + "b" }
+      canister.register(:c) { |c| c.b + "c" }
+      canister.register(:d) { |c| c.c + "d" }
+      canister.register(:e) { |c| c.d + "e" }
+      canister.register(:f) { |c| c.e + "f" }
+      canister.resolve(:f)
+      canister.register(:a) { "x" }
+      expect(canister.resolve(:f)).to eql("xbcdef")
+    end
+
+    it "resets the dependency tree on reregister" do
+      canister.register(:a) { "a" }
+      canister.register(:b1) { |c| c.a + "b1" }
+      canister.register(:b2) { |c| c.a + "b2" }
+      canister.register(:c) { |c| c.b1 + c.b2 + "c" }
+      canister.resolve(:c)
+      canister.register(:a) { "x" }
+      expect(canister.resolve(:c)).to eql("xb1xb2c")
+    end
+
+    it "ignores order" do
+      canister.register(:c) { |c| c.b + "c" }
+      canister.register(:b) { |c| c.a + "b" }
+      canister.register(:a) { "a" }
+      expect(canister.resolve(:c)).to eql("abc")
+    end
+
+    it "is apparently thread safe" do
+      threads = []
+      canister.register(:a) { "a" }
+      1000.times do
+        canister.register(:b) do |c|
+          threads << Thread.new do
+            loop do
+              sleep 0.1
+              c[:a]
+            end
+          end
+          "b"
+        end
+        canister.resolve(:b)
+      end
+      sleep 3
+      expect(canister.resolve(:b)).to eql("b")
+      threads.each(&:kill)
+    end
+  end
+
+  describe "overrides" do
+    let(:canister) do
+      described_class.new.
+        register(:a) { "a" }.
+        register(:b) { |c| c.a + "b" }.
+        register(:c) { |c| c.b + "c" }
+    end
+
+    describe "simple override" do
+
+      it "allows an override" do
+        expect(canister.resolve(:c)).to eql("abc")
+
+        canister.override do
+          canister.register(:b) { |c| c.a + "OVERRIDE" }
+          expect(canister.resolve(:c)).to eql("aOVERRIDEc")
+        end
+        expect(canister.resolve(:c)).to eql("abc")
+      end
+    end
+
+    describe "override in rspec 'around'" do
+      around(:each) do |example|
+        canister.override do
+          example.run
+        end
+      end
+
+      it "overrides with 'around'" do
+        canister.register(:b) { |c| c.a + "OVERRIDE" }
+        expect(canister.c).to eql("aOVERRIDEc")
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Uses a simple push/pop with the current context (registry, cache, etc.) to override withing the push/pop cycle, or use `container.override { ...  } ` to automatically push/pop at the beginning and end of the block.

Did I say "non-threadsafe?" OVERRIDES ARE NOT THREADSAFE!