### PR TITLE
Add ability to seed/merge with a hash-like

### DIFF
--- a/lib/canister.rb
+++ b/lib/canister.rb
@@ -6,8 +6,10 @@ require "canister/version"
 # resolved at runtime. This allows for out-of-order declaration,
 # automatic dependency resolution, and--upon
 # redeclaration--automatic dependency cache invalidation.
+# @param hashlike [#each_pair, #keys #[]]
+# @see #fill_from_hashlike
 class Canister
-  def initialize
+  def initialize(hashlike = nil)
     @stack = []
     @registry = {}
     @resolved = {}
@@ -15,7 +17,34 @@ class Canister
       hash[key] = []
     end
     @mutex = Mutex.new
+    if hashlike
+      self.fill_from_hashlike(hashlike)
+    end
     yield self if block_given?
+  end
+
+  # A "hashlike" is defined as anything that responds to both #[]
+  # and #keys and/or #each_pair
+  # Each value is wrapped in a `proc` and registered under the key.
+  # Note that Canister doesn't differentiate between symbols and
+  # strings for keys, so if your hashlike has keys of, e.g. both
+  # `"a"` and `:a` it won't work.
+  def fill_from_hashlike(hashlike)
+    iter = if hashlike.respond_to?(:each_pair)
+             hashlike.each_pair
+           else
+             if [:[], :keys].all? { |meth| hashlike.respond_to?(:meth) }
+               hashlike.lazy.keys.map { |k| [k, hashlike[h]] }
+             else
+               msg = "Need something that responds to either #each_pair or both #keys and #[]"
+               raise ArgumentError.new(msg)
+             end
+           end
+    iter.each do |k, v|
+      blk = proc { v }
+      register(k, &blk)
+    end
+    self
   end
 
   # We override method_missing to enable dot notation

--- a/lib/canister.rb
+++ b/lib/canister.rb
@@ -18,7 +18,7 @@ class Canister
     end
     @mutex = Mutex.new
     if hashlike
-      self.fill_from_hashlike(hashlike)
+      self.merge_from_hashlike(hashlike)
     end
     yield self if block_given?
   end
@@ -33,8 +33,8 @@ class Canister
     iter = if hashlike.respond_to?(:each_pair)
              hashlike.each_pair
            else
-             if [:[], :keys].all? { |meth| hashlike.respond_to?(:meth) }
-               hashlike.lazy.keys.map { |k| [k, hashlike[h]] }
+             if [:[], :keys].all? { |meth| hashlike.respond_to?(meth) }
+               hashlike.keys.lazy.map { |k| [k, hashlike[k]] }
              else
                msg = "Need something that responds to either #each_pair or both #keys and #[]"
                raise ArgumentError.new(msg)
@@ -104,6 +104,7 @@ class Canister
     end
     value
   end
+
   alias_method :[], :resolve
 
   def keys

--- a/lib/canister.rb
+++ b/lib/canister.rb
@@ -29,7 +29,7 @@ class Canister
   # Note that Canister doesn't differentiate between symbols and
   # strings for keys, so if your hashlike has keys of, e.g. both
   # `"a"` and `:a` it won't work.
-  def fill_from_hashlike(hashlike)
+  def merge_from_hashlike(hashlike)
     iter = if hashlike.respond_to?(:each_pair)
              hashlike.each_pair
            else
@@ -46,6 +46,8 @@ class Canister
     end
     self
   end
+
+  alias_method :merge, :merge_from_hashlike
 
   # We override method_missing to enable dot notation
   # for accessing registered values.

--- a/spec/canister_spec.rb
+++ b/spec/canister_spec.rb
@@ -134,4 +134,11 @@ RSpec.describe Canister do
     expect(canister.resolve(:b)).to eql("b")
     threads.each(&:kill)
   end
+
+  it "can be seeded with a hashlike" do
+    h = {a: 1, b: 2, c: proc{|a| "Hello #{a}"}}
+    c = described_class.new(h)
+    expect(c.a).to eq(1)
+    expect(c.c.call("Bill")).to eq("Hello Bill")
+  end
 end

--- a/spec/canister_spec.rb
+++ b/spec/canister_spec.rb
@@ -136,9 +136,27 @@ RSpec.describe Canister do
   end
 
   it "can be seeded with a hashlike" do
-    h = {a: 1, b: 2, c: proc{|a| "Hello #{a}"}}
+    h = { a: 1, b: 2, c: proc { |a| "Hello #{a}" } }
     c = described_class.new(h)
     expect(c.a).to eq(1)
     expect(c.c.call("Bill")).to eq("Hello Bill")
   end
+
+  # Since a canister fulfills the requirements for a hashlike,
+  # we can merge canisters as well
+  it "can merge another canister" do
+    c1 = described_class.new do |c|
+      c.register(:a) { 1 }
+      c.register(:b) { 2 }
+    end
+    c2 = described_class.new do |c|
+      c.register(:b) { 3 }
+      c.register(:d) { 4 }
+    end
+    c = c1.merge(c2)
+    expect(c.a).to eq(1)
+    expect(c.b).to eq(3)
+    expect(c.d).to eq(4)
+  end
 end
+


### PR DESCRIPTION
A hash-like is defined in the code to be something that responds to either `#each_pair` or both of `#keys` and `#[]`.

The PR allows you seed a call to `#new` with a hash-like, for putting in initial values that you maybe got from somewhere else. It also allows merging in a hash like (where the argument overwrites whatever was there). 

Canister itself fulfills the criteria for a hash-like, so you can also merge with another Canister. 

Note that Canister (at least currently) doesn't allow numeric keys, so the incoming data can't, either.

```ruby

# Seed with, or merge with, a hash
h = {a: 1, b: 2}
c = Canister.new(h)
c.a #=> 1

hello = proc{|name| "Hello #{name}"}
h2 = {b: 3, c: 3, d: hello}
c.merge(h2)
c.a #=> 1
c.b #=> 3
c.d.call("Bill") #=> "Hello Bill"

# Merge canisters
c2 = Canister.new do |can|
  can.register(:e) { 5 }
end

c2.merge(c)

c2.b #=> 3
c3.e #=> 5

```

[Also update rake version to address security update]